### PR TITLE
IBS-TH1の安定アドレス検証を追加

### DIFF
--- a/dist/ibs_th1.d.ts
+++ b/dist/ibs_th1.d.ts
@@ -3,7 +3,7 @@ import type { ProbeType } from './parser';
 type NobleEvent = 'discover' | 'stateChange';
 interface Peripheral {
     uuid: string;
-    address: string;
+    address: string | null;
     advertisement: {
         localName?: string;
         manufacturerData?: Buffer;
@@ -33,6 +33,8 @@ interface Subscription {
 declare class IbsTh1Scanner {
     private static activeScanCounts_;
     private address_fetch_status_;
+    private address_fetch_retry_at_;
+    private address_fetch_failure_count_;
     private uuid_to_address_;
     private noble_;
     private addressCache_;
@@ -54,6 +56,8 @@ declare class IbsTh1Scanner {
     private static incrementActiveScanCount_;
     private static decrementActiveScanCount_;
     private restart_;
+    private static addressRetryDelayMs_;
+    private static normalizeAddress_;
 }
 interface RealtimeData {
     address: string | null;

--- a/dist/ibs_th1.js
+++ b/dist/ibs_th1.js
@@ -44,12 +44,18 @@ Object.defineProperty(exports, "parseRealtimeData", { enumerable: true, get: fun
 const logger = Log4js.getLogger('ibs_th1');
 // Device name for IBS-TH1, IBS-TH1 mini and IBS_TH1 Plus.
 const DEVICE_NAME = 'sps';
+//const SERVICE_UUID: string = 'fff0';
+const MIN_ADDRESS_RETRY_DELAY_MS = 30000;
+const MAX_ADDRESS_RETRY_DELAY_MS = 24 * 60 * 60000;
+const ADDRESS_RETRY_BACKOFF_MULTIPLIER = 4;
 class IbsTh1Scanner {
     constructor(options = {}) {
         this.discoverListener_ = null;
         this.stateChangeListener_ = null;
         this.subscriptionId_ = 0;
         this.address_fetch_status_ = new Map();
+        this.address_fetch_retry_at_ = new Map();
+        this.address_fetch_failure_count_ = new Map();
         this.noble_ = options.noble || loadDefaultNoble();
         this.addressCache_ = options.addressCache || new FileAddressCache('uuid_to_address');
         this.uuid_to_address_ = this.addressCache_.load();
@@ -160,17 +166,35 @@ class IbsTh1Scanner {
             // Another thread is checking the address now.
             throw new Error('Discovered => Address fetch on flight. Ignoring.');
         }
-        const address = this.uuid_to_address_.get(peripheral.uuid);
+        const address = IbsTh1Scanner.normalizeAddress_(this.uuid_to_address_.get(peripheral.uuid));
         if (!address) {
+            const retryAt = this.address_fetch_retry_at_.get(peripheral.uuid);
+            if (retryAt != null && Date.now() < retryAt) {
+                throw new Error('Discovered => Address fetch cooling down. Ignoring.');
+            }
             // Check the address from now.
             this.address_fetch_status_.set(peripheral.uuid, 'FETCHING');
             try {
                 const address = await this.getAddress_(peripheral);
+                this.address_fetch_retry_at_.delete(peripheral.uuid);
+                this.address_fetch_failure_count_.delete(peripheral.uuid);
                 this.address_fetch_status_.set(peripheral.uuid, 'FETCHED');
                 this.uuid_to_address_.set(peripheral.uuid, address);
                 this.addressCache_.save(this.uuid_to_address_);
             }
             catch (err) {
+                if (err instanceof InvalidAddressError) {
+                    const failureCount = (this.address_fetch_failure_count_.get(peripheral.uuid) || 0) + 1;
+                    const retryDelayMs = IbsTh1Scanner.addressRetryDelayMs_(failureCount);
+                    this.address_fetch_failure_count_.set(peripheral.uuid, failureCount);
+                    this.address_fetch_retry_at_.set(peripheral.uuid, Date.now() + retryDelayMs);
+                    logger.warn('Unable to get stable address for peripheral device', {
+                        uuid: peripheral.uuid,
+                        address: peripheral.address,
+                        failureCount,
+                        retryDelayMs,
+                    });
+                }
                 this.address_fetch_status_.delete(peripheral.uuid);
                 throw err;
             }
@@ -189,7 +213,7 @@ class IbsTh1Scanner {
         }
         const realtimeData = {
             date: new Date,
-            address: this.uuid_to_address_.get(peripheral.uuid) || null,
+            address: IbsTh1Scanner.normalizeAddress_(this.uuid_to_address_.get(peripheral.uuid)),
             temperatureCelsius: parsedData.temperatureCelsius,
             humidityPercent: parsedData.humidityPercent,
             probeType: parsedData.probeType,
@@ -207,7 +231,11 @@ class IbsTh1Scanner {
                 throw new Error('No UUID');
             }
             logger.debug('Connected', { 'uuid': peripheral.uuid, 'address': peripheral.address });
-            return peripheral.address;
+            const address = IbsTh1Scanner.normalizeAddress_(peripheral.address);
+            if (address == null) {
+                throw new InvalidAddressError(`No stable address for peripheral device with uuid = ${peripheral.uuid}`);
+            }
+            return address;
         }
         finally {
             if (connected) {
@@ -246,9 +274,28 @@ class IbsTh1Scanner {
         this.stop_();
         this.subscribe(callback);
     }
+    static addressRetryDelayMs_(failureCount) {
+        return Math.min(MIN_ADDRESS_RETRY_DELAY_MS * Math.pow(ADDRESS_RETRY_BACKOFF_MULTIPLIER, failureCount - 1), MAX_ADDRESS_RETRY_DELAY_MS);
+    }
+    static normalizeAddress_(address) {
+        if (address == null) {
+            return null;
+        }
+        const normalizedAddress = address.trim();
+        if (!normalizedAddress) {
+            return null;
+        }
+        const lowerAddress = normalizedAddress.toLowerCase();
+        if (lowerAddress === 'unknown' || lowerAddress === '00:00:00:00:00:00') {
+            return null;
+        }
+        return normalizedAddress;
+    }
 }
 exports.IbsTh1Scanner = IbsTh1Scanner;
 IbsTh1Scanner.activeScanCounts_ = new Map();
+class InvalidAddressError extends Error {
+}
 class FileAddressCache {
     constructor(configName, homeDir = os.homedir()) {
         this.homeDir_ = homeDir;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ibs_th1",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ibs_th1",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "os": [
         "darwin",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "license": "MIT",
   "name": "ibs_th1",
   "description": "Library to process data broadcasted from IBS-TH1 / IBS-TH1 mini / IBS-TH1 Plus.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/pascaljp/ibs_th1.git"

--- a/src/ibs_th1.ts
+++ b/src/ibs_th1.ts
@@ -12,6 +12,9 @@ const logger = Log4js.getLogger('ibs_th1');
 // Device name for IBS-TH1, IBS-TH1 mini and IBS_TH1 Plus.
 const DEVICE_NAME: string = 'sps';
 //const SERVICE_UUID: string = 'fff0';
+const MIN_ADDRESS_RETRY_DELAY_MS = 30_000;
+const MAX_ADDRESS_RETRY_DELAY_MS = 24 * 60 * 60_000;
+const ADDRESS_RETRY_BACKOFF_MULTIPLIER = 4;
 
 type AddressFetchStatus = 'FETCHING' | 'FETCHED';
 
@@ -19,7 +22,7 @@ type NobleEvent = 'discover' | 'stateChange';
 
 interface Peripheral {
   uuid: string;
-  address: string;
+  address: string | null;
   advertisement: {
     localName?: string;
     manufacturerData?: Buffer;
@@ -55,6 +58,8 @@ class IbsTh1Scanner {
   private static activeScanCounts_: Map<NobleAdapter, number> = new Map();
 
   private address_fetch_status_: Map<string, AddressFetchStatus>;
+  private address_fetch_retry_at_: Map<string, number>;
+  private address_fetch_failure_count_: Map<string, number>;
   private uuid_to_address_: Map<string, string>;
   private noble_: NobleAdapter;
   private addressCache_: AddressCache;
@@ -64,6 +69,8 @@ class IbsTh1Scanner {
 
   constructor(options: IbsTh1ScannerOptions = {}) {
     this.address_fetch_status_ = new Map<string, AddressFetchStatus>();
+    this.address_fetch_retry_at_ = new Map<string, number>();
+    this.address_fetch_failure_count_ = new Map<string, number>();
     this.noble_ = options.noble || loadDefaultNoble();
     this.addressCache_ = options.addressCache || new FileAddressCache('uuid_to_address');
     this.uuid_to_address_ = this.addressCache_.load();
@@ -184,18 +191,41 @@ class IbsTh1Scanner {
       throw new Error('Discovered => Address fetch on flight. Ignoring.');
     }
 
-    const address = this.uuid_to_address_.get(peripheral.uuid);
+    const address = IbsTh1Scanner.normalizeAddress_(this.uuid_to_address_.get(peripheral.uuid));
     if (!address) {
+      const retryAt = this.address_fetch_retry_at_.get(peripheral.uuid);
+      if (retryAt != null && Date.now() < retryAt) {
+        throw new Error('Discovered => Address fetch cooling down. Ignoring.');
+      }
+
       // Check the address from now.
       this.address_fetch_status_.set(peripheral.uuid, 'FETCHING');
       try {
         const address: string = await this.getAddress_(peripheral);
 
+        this.address_fetch_retry_at_.delete(peripheral.uuid);
+        this.address_fetch_failure_count_.delete(peripheral.uuid);
         this.address_fetch_status_.set(peripheral.uuid, 'FETCHED');
         this.uuid_to_address_.set(peripheral.uuid, address);
         this.addressCache_.save(this.uuid_to_address_);
       } catch (err) {
-      this.address_fetch_status_.delete(peripheral.uuid);
+        if (err instanceof InvalidAddressError) {
+          const failureCount = (this.address_fetch_failure_count_.get(peripheral.uuid) || 0) + 1;
+          const retryDelayMs = IbsTh1Scanner.addressRetryDelayMs_(failureCount);
+          this.address_fetch_failure_count_.set(peripheral.uuid, failureCount);
+          this.address_fetch_retry_at_.set(
+            peripheral.uuid,
+            Date.now() + retryDelayMs);
+          logger.warn(
+            'Unable to get stable address for peripheral device',
+            {
+              uuid: peripheral.uuid,
+              address: peripheral.address,
+              failureCount,
+              retryDelayMs,
+            });
+        }
+        this.address_fetch_status_.delete(peripheral.uuid);
         throw err;
       }
 
@@ -216,7 +246,7 @@ class IbsTh1Scanner {
 
     const realtimeData: RealtimeData = {
       date: new Date,
-      address: this.uuid_to_address_.get(peripheral.uuid) || null,
+      address: IbsTh1Scanner.normalizeAddress_(this.uuid_to_address_.get(peripheral.uuid)),
       temperatureCelsius: parsedData.temperatureCelsius,
       humidityPercent: parsedData.humidityPercent,
       probeType: parsedData.probeType,
@@ -235,7 +265,11 @@ class IbsTh1Scanner {
         throw new Error('No UUID');
       }
       logger.debug('Connected', { 'uuid': peripheral.uuid, 'address': peripheral.address });
-      return peripheral.address;
+      const address = IbsTh1Scanner.normalizeAddress_(peripheral.address);
+      if (address == null) {
+        throw new InvalidAddressError(`No stable address for peripheral device with uuid = ${peripheral.uuid}`);
+      }
+      return address;
     } finally {
       if (connected) {
         try {
@@ -275,6 +309,31 @@ class IbsTh1Scanner {
     this.stop_();
     this.subscribe(callback);
   }
+
+  private static addressRetryDelayMs_(failureCount: number): number {
+    return Math.min(
+      MIN_ADDRESS_RETRY_DELAY_MS * Math.pow(ADDRESS_RETRY_BACKOFF_MULTIPLIER, failureCount - 1),
+      MAX_ADDRESS_RETRY_DELAY_MS);
+  }
+
+  private static normalizeAddress_(address: string | null | undefined): string | null {
+    if (address == null) {
+      return null;
+    }
+    const normalizedAddress = address.trim();
+    if (!normalizedAddress) {
+      return null;
+    }
+
+    const lowerAddress = normalizedAddress.toLowerCase();
+    if (lowerAddress === 'unknown' || lowerAddress === '00:00:00:00:00:00') {
+      return null;
+    }
+    return normalizedAddress;
+  }
+}
+
+class InvalidAddressError extends Error {
 }
 
 interface RealtimeData {

--- a/tests/scanner.test.ts
+++ b/tests/scanner.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { EventEmitter } from 'node:events';
 import fs from 'node:fs';
+import * as Log4js from 'log4js';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
@@ -56,7 +57,7 @@ class MemoryAddressCache implements AddressCache {
 
 function peripheral(options: {
   uuid: string;
-  address?: string;
+  address?: string | null;
   connectError?: Error;
   localName?: string;
   manufacturerData?: Buffer;
@@ -65,7 +66,7 @@ function peripheral(options: {
 }): Peripheral {
   return {
     uuid: options.uuid,
-    address: options.address || 'aa:bb:cc:dd:ee:ff',
+    address: 'address' in options ? options.address ?? null : 'aa:bb:cc:dd:ee:ff',
     advertisement: {
       localName: options.localName ?? 'sps',
       manufacturerData: options.manufacturerData ?? Buffer.from([
@@ -129,6 +130,102 @@ test('address fetch failure is retryable and successful fetch is cached', async 
   assert.equal(cache.saveCalls, 1);
   assert.equal(received.length, 2);
   subscription.unsubscribe();
+});
+
+test('invalid address fetch is retryable and is not cached', async () => {
+  const noble = new MockNoble();
+  const cache = new MemoryAddressCache();
+  let now = 0;
+  const originalDateNow = Date.now;
+  Date.now = () => now;
+  Log4js.configure({
+    appenders: { recorded: { type: 'recording' } },
+    categories: { default: { appenders: ['recorded'], level: 'warn' } },
+  });
+  const recording = Log4js.recording();
+  recording.reset();
+  const scanner = new IbsTh1Scanner({ noble, addressCache: cache });
+  const received: any[] = [];
+  let connectCalls = 0;
+
+  const subscription = scanner.subscribe(data => received.push(data));
+  try {
+    for (const address of [null, '', '   ', ' unknown ', '00:00:00:00:00:00']) {
+      noble.discover(peripheral({
+        uuid: 'device-1',
+        address,
+        onConnect: () => {
+          connectCalls++;
+        },
+      }));
+      await new Promise(resolve => setImmediate(resolve));
+    }
+    noble.discover(peripheral({
+      uuid: 'device-1',
+      address: ' aa:bb:cc:dd:ee:ff ',
+      onConnect: () => {
+        connectCalls++;
+      },
+    }));
+    await new Promise(resolve => setImmediate(resolve));
+    noble.discover(peripheral({ uuid: 'device-1', address: 'ignored-after-cache' }));
+    await new Promise(resolve => setImmediate(resolve));
+
+    assert.equal(connectCalls, 1);
+    assert.equal(cache.get('device-1'), undefined);
+    assert.equal(cache.saveCalls, 0);
+    assert.equal(received.length, 0);
+    assert.equal(recording.replay().length, 1);
+    assert.match(recording.replay()[0]?.data.join(' '), /Unable to get stable address/);
+
+    now = 30_000;
+    noble.discover(peripheral({
+      uuid: 'device-1',
+      address: '00:00:00:00:00:00',
+      onConnect: () => {
+        connectCalls++;
+      },
+    }));
+    await new Promise(resolve => setImmediate(resolve));
+
+    now = 149_999;
+    noble.discover(peripheral({
+      uuid: 'device-1',
+      address: ' aa:bb:cc:dd:ee:ff ',
+      onConnect: () => {
+        connectCalls++;
+      },
+    }));
+    await new Promise(resolve => setImmediate(resolve));
+
+    assert.equal(connectCalls, 2);
+    assert.equal(cache.get('device-1'), undefined);
+    assert.equal(cache.saveCalls, 0);
+    assert.equal(received.length, 0);
+    assert.equal(recording.replay().length, 2);
+
+    now = 150_000;
+    noble.discover(peripheral({
+      uuid: 'device-1',
+      address: ' aa:bb:cc:dd:ee:ff ',
+      onConnect: () => {
+        connectCalls++;
+      },
+    }));
+    await new Promise(resolve => setImmediate(resolve));
+    noble.discover(peripheral({ uuid: 'device-1', address: 'ignored-after-cache' }));
+    await new Promise(resolve => setImmediate(resolve));
+
+    assert.equal(connectCalls, 3);
+    assert.equal(cache.get('device-1'), 'aa:bb:cc:dd:ee:ff');
+    assert.equal(cache.saveCalls, 1);
+    assert.equal(received.length, 2);
+    assert.equal(received[0].address, 'aa:bb:cc:dd:ee:ff');
+    assert.equal(received[1].address, 'aa:bb:cc:dd:ee:ff');
+  } finally {
+    Date.now = originalDateNow;
+    subscription.unsubscribe();
+  }
 });
 
 test('cached addresses avoid connection and cache writes', async () => {


### PR DESCRIPTION
## 概要
- Peripheral address を正規化し、空文字・unknown・ゼロMACを無効扱いに変更
- 無効 address をキャッシュせず、4倍指数バックオフ（最大24時間）で再試行するように変更
- 無効 address を実際に取得したタイミングだけ warning ログを出力
- package version を 2.0.1 に更新

## レビュー結果
- Critical: なし
- Warning: なし
- Suggestion: なし

## 検証
- npm test
- npm run build
