### PR TITLE
古い address 識別子名を削除

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Version 2.0.3
+
+* Remove legacy identity naming from public types, documentation, and tests.
+* Log when the scanner connects to a device to resolve its stable device id.
+* Change stable device-id retry backoff to 2x intervals capped at one hour.
+
 ## Version 2.0.0
 
 * Add a testable `parseRealtimeData` parser entry point.
@@ -6,20 +12,22 @@
 * Rename realtime fields to explicit units: `temperatureCelsius`,
   `humidityPercent`, and `batteryPercent`; probe types are now lowercase.
 * Add `crc16(buffer)` as the public CRC helper.
-* Keep UUID-to-address cache persistence while making corrupt cache files safer.
+* Keep scanner device-id cache persistence while making corrupt cache files
+  safer.
 * Avoid removing other Noble listeners when unsubscribing.
 * Move `@abandonware/noble` to an optional peer dependency so parser users do
   not install the native BLE stack.
 * Require Node.js 18 or newer for the modernized toolchain and package shape.
 * Split hardware-dependent scanning samples from automated tests and expand
-  unit coverage for parser, scanner lifecycle, address caching, and packaging.
+  unit coverage for parser, scanner lifecycle, device-id caching, and
+  packaging.
 
 ## Version 1.2.0
 
 * Change the language from JavaScript to TypeScript.
 * Deleted some legacy code.
   * Type of data.proveType is changed from number to a descriptive string.
-  * data.uuid is no longer available. Please use data.address instead.
+  * The unstable UUID-based callback field is no longer available.
 
 ## Version 1.1.0
 
@@ -31,5 +39,5 @@
 * Since noble package is not maintained well, now this package depends on @abandonware/noble. Installation became easier.
 * The behavior of the system became stable.
 * The object passed to callback function became an instance of IBS_TH1.RealtimeData.
-* Deprecate IBS_TH1.RealtimeData.uuid field because that field is not stable enough. When we change bettery of IBS_TH1 device it changes. Users should use IBS_TH1.RealtimeData.address field that is stable over time.
+* Deprecate the unstable UUID-based identity field in IBS_TH1.RealtimeData.
 * Reduce connections to IBS_TH1 devices to save their battery.

--- a/README.md
+++ b/README.md
@@ -60,8 +60,7 @@ the active subscription.
 
 `data.deviceId` is a stable identifier derived from the Device Information
 Service System ID characteristic (`180a` / `2a23`) and is returned as
-`ibs-th1-system-id:<hex>`. The scanner does not use `peripheral.address` as a
-device identifier.
+`ibs-th1-system-id:<hex>`.
 
 If you already have an IBS-TH1 manufacturer data buffer and only need to decode
 it, use the parser entry point. This does not start Bluetooth scanning.

--- a/dist/ibs_th1.d.ts
+++ b/dist/ibs_th1.d.ts
@@ -3,7 +3,6 @@ import type { ProbeType } from './parser';
 type NobleEvent = 'discover' | 'stateChange';
 interface Peripheral {
     uuid: string;
-    address: string | null;
     advertisement: {
         localName?: string;
         manufacturerData?: Buffer;

--- a/dist/ibs_th1.js
+++ b/dist/ibs_th1.js
@@ -64,8 +64,8 @@ const SYSTEM_ID_CHARACTERISTIC_UUID = '2a23';
 const SYSTEM_ID_DEVICE_ID_PREFIX = 'ibs-th1-system-id:';
 //const SERVICE_UUID: string = 'fff0';
 const MIN_DEVICE_ID_RETRY_DELAY_MS = 30000;
-const MAX_DEVICE_ID_RETRY_DELAY_MS = 24 * 60 * 60000;
-const DEVICE_ID_RETRY_BACKOFF_MULTIPLIER = 4;
+const MAX_DEVICE_ID_RETRY_DELAY_MS = 60 * 60000;
+const DEVICE_ID_RETRY_BACKOFF_MULTIPLIER = 2;
 class IbsTh1Scanner {
     constructor(options = {}) {
         this.discoverListener_ = null;
@@ -272,6 +272,7 @@ class IbsTh1Scanner {
         logger.debug('Getting device id of peripheral device with uuid =', peripheral.uuid);
         let connected = false;
         try {
+            logger.info('Connecting to peripheral device to resolve stable device id', { uuid: peripheral.uuid });
             diagnosticsLog('Connecting for device id resolution', { uuid: peripheral.uuid });
             await peripheral.connectAsync();
             connected = true;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ibs_th1",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ibs_th1",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "MIT",
       "os": [
         "darwin",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "license": "MIT",
   "name": "ibs_th1",
   "description": "Library to process data broadcasted from IBS-TH1 / IBS-TH1 mini / IBS-TH1 Plus.",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/pascaljp/ibs_th1.git"

--- a/src/ibs_th1.ts
+++ b/src/ibs_th1.ts
@@ -33,8 +33,8 @@ const SYSTEM_ID_CHARACTERISTIC_UUID = '2a23';
 const SYSTEM_ID_DEVICE_ID_PREFIX = 'ibs-th1-system-id:';
 //const SERVICE_UUID: string = 'fff0';
 const MIN_DEVICE_ID_RETRY_DELAY_MS = 30_000;
-const MAX_DEVICE_ID_RETRY_DELAY_MS = 24 * 60 * 60_000;
-const DEVICE_ID_RETRY_BACKOFF_MULTIPLIER = 4;
+const MAX_DEVICE_ID_RETRY_DELAY_MS = 60 * 60_000;
+const DEVICE_ID_RETRY_BACKOFF_MULTIPLIER = 2;
 
 type DeviceIdFetchStatus = 'FETCHING' | 'FETCHED';
 
@@ -42,7 +42,6 @@ type NobleEvent = 'discover' | 'stateChange';
 
 interface Peripheral {
   uuid: string;
-  address: string | null;
   advertisement: {
     localName?: string;
     manufacturerData?: Buffer;
@@ -316,6 +315,7 @@ class IbsTh1Scanner {
     logger.debug('Getting device id of peripheral device with uuid =', peripheral.uuid);
     let connected = false;
     try {
+      logger.info('Connecting to peripheral device to resolve stable device id', { uuid: peripheral.uuid });
       diagnosticsLog('Connecting for device id resolution', { uuid: peripheral.uuid });
       await peripheral.connectAsync();
       connected = true;

--- a/tests/scanner.test.ts
+++ b/tests/scanner.test.ts
@@ -69,7 +69,6 @@ class MemoryDeviceIdCache implements DeviceIdCache {
 
 function peripheral(options: {
   uuid: string;
-  address?: string | null;
   systemId?: Buffer | null;
   connectError?: Error;
   discoverError?: Error;
@@ -81,7 +80,6 @@ function peripheral(options: {
 }): MockPeripheral {
   return {
     uuid: options.uuid,
-    address: 'address' in options ? options.address ?? null : 'aa:bb:cc:dd:ee:ff',
     advertisement: {
       localName: options.localName ?? 'sps',
       manufacturerData: options.manufacturerData ?? Buffer.from([
@@ -159,18 +157,16 @@ test('system id fetch failure is retryable and successful fetch is cached', asyn
   await new Promise(resolve => setImmediate(resolve));
   noble.discover(peripheral({
     uuid: 'device-1',
-    address: '',
     systemId: Buffer.from('982f000000064249', 'hex'),
   }));
   await new Promise(resolve => setImmediate(resolve));
-  noble.discover(peripheral({ uuid: 'device-1', address: '' }));
+  noble.discover(peripheral({ uuid: 'device-1' }));
   await new Promise(resolve => setImmediate(resolve));
 
   assert.equal(cache.get('device-1'), 'ibs-th1-system-id:982f000000064249');
   assert.equal(cache.saveCalls, 1);
   assert.equal(received.length, 2);
   assert.equal((received[0] as any).deviceId, 'ibs-th1-system-id:982f000000064249');
-  assert.equal('address' in (received[0] as any), false);
   subscription.unsubscribe();
 });
 
@@ -195,7 +191,6 @@ test('invalid system id fetch is retryable and is not cached', async () => {
     for (const systemId of [null, Buffer.alloc(0), Buffer.alloc(8)]) {
       noble.discover(peripheral({
         uuid: 'device-1',
-        address: '',
         systemId,
         onConnect: () => {
           connectCalls++;
@@ -205,14 +200,13 @@ test('invalid system id fetch is retryable and is not cached', async () => {
     }
     noble.discover(peripheral({
       uuid: 'device-1',
-      address: '',
       systemId: Buffer.from('982f000000064249', 'hex'),
       onConnect: () => {
         connectCalls++;
       },
     }));
     await new Promise(resolve => setImmediate(resolve));
-    noble.discover(peripheral({ uuid: 'device-1', address: '' }));
+    noble.discover(peripheral({ uuid: 'device-1' }));
     await new Promise(resolve => setImmediate(resolve));
 
     assert.equal(connectCalls, 1);
@@ -225,7 +219,6 @@ test('invalid system id fetch is retryable and is not cached', async () => {
     now = 30_000;
     noble.discover(peripheral({
       uuid: 'device-1',
-      address: '',
       systemId: Buffer.alloc(8),
       onConnect: () => {
         connectCalls++;
@@ -233,10 +226,9 @@ test('invalid system id fetch is retryable and is not cached', async () => {
     }));
     await new Promise(resolve => setImmediate(resolve));
 
-    now = 149_999;
+    now = 89_999;
     noble.discover(peripheral({
       uuid: 'device-1',
-      address: '',
       systemId: Buffer.from('982f000000064249', 'hex'),
       onConnect: () => {
         connectCalls++;
@@ -250,17 +242,16 @@ test('invalid system id fetch is retryable and is not cached', async () => {
     assert.equal(received.length, 0);
     assert.equal(recording.replay().length, 2);
 
-    now = 150_000;
+    now = 90_000;
     noble.discover(peripheral({
       uuid: 'device-1',
-      address: '',
       systemId: Buffer.from('982f000000064249', 'hex'),
       onConnect: () => {
         connectCalls++;
       },
     }));
     await new Promise(resolve => setImmediate(resolve));
-    noble.discover(peripheral({ uuid: 'device-1', address: '' }));
+    noble.discover(peripheral({ uuid: 'device-1' }));
     await new Promise(resolve => setImmediate(resolve));
 
     assert.equal(connectCalls, 3);
@@ -269,6 +260,70 @@ test('invalid system id fetch is retryable and is not cached', async () => {
     assert.equal(received.length, 2);
     assert.equal(received[0].deviceId, 'ibs-th1-system-id:982f000000064249');
     assert.equal(received[1].deviceId, 'ibs-th1-system-id:982f000000064249');
+  } finally {
+    Date.now = originalDateNow;
+    subscription.unsubscribe();
+  }
+});
+
+test('device id fetch retry backs off by 2x and caps at one hour', async () => {
+  const noble = new MockNoble();
+  const cache = new MemoryDeviceIdCache();
+  let now = 0;
+  const originalDateNow = Date.now;
+  Date.now = () => now;
+  const scanner = new IbsTh1Scanner({ noble, deviceIdCache: cache });
+  let connectCalls = 0;
+
+  const subscription = scanner.subscribe(() => {});
+  try {
+    const retryAtByFailure = [
+      30_000,
+      90_000,
+      210_000,
+      450_000,
+      930_000,
+      1_890_000,
+      3_810_000,
+      7_410_000,
+    ];
+
+    for (const retryAt of retryAtByFailure) {
+      noble.discover(peripheral({
+        uuid: 'device-1',
+        systemId: Buffer.alloc(8),
+        onConnect: () => {
+          connectCalls++;
+        },
+      }));
+      await new Promise(resolve => setImmediate(resolve));
+      now = retryAt;
+    }
+
+    assert.equal(connectCalls, retryAtByFailure.length);
+
+    now = 7_409_999;
+    noble.discover(peripheral({
+      uuid: 'device-1',
+      systemId: Buffer.from('982f000000064249', 'hex'),
+      onConnect: () => {
+        connectCalls++;
+      },
+    }));
+    await new Promise(resolve => setImmediate(resolve));
+    assert.equal(connectCalls, retryAtByFailure.length);
+
+    now = 7_410_000;
+    noble.discover(peripheral({
+      uuid: 'device-1',
+      systemId: Buffer.from('982f000000064249', 'hex'),
+      onConnect: () => {
+        connectCalls++;
+      },
+    }));
+    await new Promise(resolve => setImmediate(resolve));
+    assert.equal(connectCalls, retryAtByFailure.length + 1);
+    assert.equal(cache.get('device-1'), 'ibs-th1-system-id:982f000000064249');
   } finally {
     Date.now = originalDateNow;
     subscription.unsubscribe();
@@ -295,7 +350,6 @@ test('cached device ids avoid connection and cache writes', async () => {
   assert.equal(cache.saveCalls, 0);
   assert.equal(received.length, 1);
   assert.equal(received[0].deviceId, 'ibs-th1-system-id:982f000000064249');
-  assert.equal('address' in received[0], false);
   assert.equal(received[0].temperatureCelsius, 12.34);
   assert.equal(received[0].humidityPercent, 60.1);
   assert.equal(received[0].batteryPercent, 99);
@@ -372,6 +426,12 @@ test('non-target advertisements are ignored without connecting', async () => {
 test('successful system id fetch disconnects before emitting data', async () => {
   const noble = new MockNoble();
   const cache = new MemoryDeviceIdCache();
+  Log4js.configure({
+    appenders: { recorded: { type: 'recording' } },
+    categories: { default: { appenders: ['recorded'], level: 'info' } },
+  });
+  const recording = Log4js.recording();
+  recording.reset();
   const scanner = new IbsTh1Scanner({ noble, deviceIdCache: cache });
   const events: string[] = [];
 
@@ -385,6 +445,10 @@ test('successful system id fetch disconnects before emitting data', async () => 
   await new Promise(resolve => setImmediate(resolve));
 
   assert.deepEqual(events, ['connect', 'disconnect', 'callback']);
+  assert.match(
+    recording.replay().map(event => event.data.join(' ')).join('\n'),
+    /Connecting to peripheral device to resolve stable device id/,
+  );
   subscription.unsubscribe();
 });
 


### PR DESCRIPTION
## 概要
- package version を 2.0.3 に更新
- 公開型の Peripheral から legacy identity field を削除
- README と CHANGELOG から古い識別子名への言及を削除
- stable device id 取得時の接続ログを追加
- deviceId 取得失敗時の backoff を2倍刻み、最大1時間に変更

## 確認
- npm test
- rg -n "\baddress\b|peripheral\.address|data\.address|RealtimeData\.address|uuid_to_address|address caching|UUID-to-address" . --glob '!node_modules/**' --glob '!.git/**' がヒットなし